### PR TITLE
Rust code safety

### DIFF
--- a/src/joycon/device.rs
+++ b/src/joycon/device.rs
@@ -290,7 +290,7 @@ impl JoyCon {
     ///
     /// // Spawn threads for each JoyCon (simplified example)
     /// // ... then trigger synchronized start:
-    /// *signal.lock().unwrap() = true;
+    /// *signal.lock().unwrap_or_else(|e| e.into_inner()) = true;
     /// # Ok(())
     /// # }
     /// ```
@@ -303,7 +303,7 @@ impl JoyCon {
         track: RumbleTrack,
         start_signal: Arc<Mutex<bool>>,
     ) -> Result<(), JoyConError> {
-        while !*start_signal.lock().unwrap() {
+        while !*start_signal.lock().unwrap_or_else(|e| e.into_inner()) {
             thread::sleep(Duration::from_millis(1));
         }
 

--- a/src/midi/playback.rs
+++ b/src/midi/playback.rs
@@ -153,7 +153,7 @@ pub fn play_midi_file(path: PathBuf) -> Result<(), Box<dyn std::error::Error + S
         return Err("No playable tracks found in MIDI file".into());
     }
 
-    track_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+    track_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
     let initial_assignments: Vec<usize> = track_scores
         .iter()
@@ -182,7 +182,7 @@ pub fn play_midi_file(path: PathBuf) -> Result<(), Box<dyn std::error::Error + S
     let ranking_tracks = tracks.clone();
 
     thread::spawn(move || {
-        while !*ranking_signal.lock().unwrap() {
+        while !*ranking_signal.lock().unwrap_or_else(|e| e.into_inner()) {
             thread::sleep(Duration::from_millis(1));
         }
 
@@ -194,7 +194,7 @@ pub fn play_midi_file(path: PathBuf) -> Result<(), Box<dyn std::error::Error + S
                 .iter()
                 .enumerate()
                 .filter(|(idx, track)| {
-                    ranking_active.lock().unwrap()[*idx] && !track.metrics.is_percussion
+                    ranking_active.lock().unwrap_or_else(|e| e.into_inner())[*idx] && !track.metrics.is_percussion
                 })
                 .map(|(idx, track)| {
                     let (note_count, max_amp) = TrackMergeController::evaluate_track_section(
@@ -215,7 +215,7 @@ pub fn play_midi_file(path: PathBuf) -> Result<(), Box<dyn std::error::Error + S
                 .collect();
 
             // Sort by note count first, then by score
-            track_scores.sort_by(|a, b| b.2.cmp(&a.2).then_with(|| b.1.partial_cmp(&a.1).unwrap()));
+            track_scores.sort_by(|a, b| b.2.cmp(&a.2).then_with(|| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal)));
 
             // Take the top N tracks for N JoyCons
             let mut new_assignments = vec![];
@@ -225,7 +225,7 @@ pub fn play_midi_file(path: PathBuf) -> Result<(), Box<dyn std::error::Error + S
 
             // Update assignments if changed and there are active notes
             let mut assignments: std::sync::MutexGuard<'_, Vec<usize>> =
-                ranking_assignments.lock().unwrap();
+                ranking_assignments.lock().unwrap_or_else(|e| e.into_inner());
             if *assignments != new_assignments {
                 let should_switch = track_scores
                     .iter()
@@ -256,7 +256,7 @@ pub fn play_midi_file(path: PathBuf) -> Result<(), Box<dyn std::error::Error + S
             current_time += RANKING_WINDOW / 2;
 
             // Check if all tracks are complete
-            if ranking_active.lock().unwrap().iter().all(|&active| !active) {
+            if ranking_active.lock().unwrap_or_else(|e| e.into_inner()).iter().all(|&active| !active) {
                 break;
             }
         }
@@ -277,7 +277,7 @@ pub fn play_midi_file(path: PathBuf) -> Result<(), Box<dyn std::error::Error + S
         let merge_controller = Arc::clone(&merge_controller);
 
         handles.push(thread::spawn(move || {
-            while !*joycon_signal.lock().unwrap() {
+            while !*joycon_signal.lock().unwrap_or_else(|e| e.into_inner()) {
                 thread::sleep(Duration::from_millis(1));
             }
 
@@ -295,17 +295,17 @@ pub fn play_midi_file(path: PathBuf) -> Result<(), Box<dyn std::error::Error + S
                         joycon_idx + 1,
                         current_track_idx
                     );
-                    joycon_active.lock().unwrap()[current_track_idx] = false;
+                    joycon_active.lock().unwrap_or_else(|e| e.into_inner())[current_track_idx] = false;
                     break;
                 }
 
                 // Check for track reassignment
-                let assignments = joycon_assignments.lock().unwrap();
+                let assignments = joycon_assignments.lock().unwrap_or_else(|e| e.into_inner());
                 let assigned_track_idx = assignments[joycon_idx];
                 drop(assignments);
 
                 if assigned_track_idx != current_track_idx {
-                    let should_switch = merge_controller.lock().unwrap().should_switch_tracks(
+                    let should_switch = merge_controller.lock().unwrap_or_else(|e| e.into_inner()).should_switch_tracks(
                         joycon_idx,
                         current_track_idx,
                         assigned_track_idx,
@@ -347,7 +347,7 @@ pub fn play_midi_file(path: PathBuf) -> Result<(), Box<dyn std::error::Error + S
                         );
                         command_index = new_index;
                         pending_track_switch = None;
-                        merge_controller.lock().unwrap().record_switch(joycon_idx);
+                        merge_controller.lock().unwrap_or_else(|e| e.into_inner()).record_switch(joycon_idx);
                         continue; // Restart loop with new track
                     }
                 }
@@ -367,7 +367,7 @@ pub fn play_midi_file(path: PathBuf) -> Result<(), Box<dyn std::error::Error + S
                     thread::sleep(cmd.wait_before);
                     merge_controller
                         .lock()
-                        .unwrap()
+                        .unwrap_or_else(|e| e.into_inner())
                         .update_time(cmd.wait_before);
                     current_time += cmd.wait_before;
                 }
@@ -385,11 +385,14 @@ pub fn play_midi_file(path: PathBuf) -> Result<(), Box<dyn std::error::Error + S
 
     // Start playback
     println!("\n▶️ Starting playback...");
-    *start_signal.lock().unwrap() = true;
+    *start_signal.lock().unwrap_or_else(|e| e.into_inner()) = true;
 
     // Wait for all tracks to complete
     for handle in handles {
-        handle.join().unwrap()?;
+        match handle.join() {
+            Ok(result) => result?,
+            Err(_) => return Err("A playback thread panicked".into()),
+        }
     }
 
     println!("✨ Playback complete!");

--- a/src/midi/rumble.rs
+++ b/src/midi/rumble.rs
@@ -352,14 +352,14 @@ fn convert_track_with_tempo(
     }
     let final_duration = ticks_to_duration(0, current_time_ticks, tempo_changes, ticks_per_beat);
 
-    if !commands.is_empty()
-        && (commands.last().unwrap().frequency != 0.0 || commands.last().unwrap().amplitude != 0.0)
-    {
-        commands.push(RumbleCommand {
-            frequency: 0.0,
-            amplitude: 0.0,
-            wait_before: Duration::ZERO,
-        });
+    if let Some(last) = commands.last() {
+        if last.frequency != 0.0 || last.amplitude != 0.0 {
+            commands.push(RumbleCommand {
+                frequency: 0.0,
+                amplitude: 0.0,
+                wait_before: Duration::ZERO,
+            });
+        }
     }
 
     let silent_periods = find_silent_periods(&commands);
@@ -664,7 +664,7 @@ pub fn parse_midi_to_rumble(
         track_metrics.sort_by(|a, b| {
             b.calculate_score()
                 .partial_cmp(&a.calculate_score())
-                .unwrap()
+                .unwrap_or(std::cmp::Ordering::Equal)
         });
 
         // Take all valid tracks (not just num_joycons)
@@ -772,7 +772,7 @@ pub fn parse_midi_to_rumble(
                 .collect();
 
             // Sort available tracks by score
-            available_tracks.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+            available_tracks.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
             if let Some((best_idx, score)) = available_tracks.first() {
                 println!("  ✨ At {:?}: Best alternative for track {} is track {} (score: {:.2})", 


### PR DESCRIPTION
Refactor `unwrap()` calls to improve memory safety and robustness by handling potential panics gracefully.

This PR addresses `partial_cmp().unwrap()` for `f32` (handling NaN), `Option::unwrap()` after checks (using `if let Some`), `Mutex::lock().unwrap()` (implementing poison recovery), and `thread::join().unwrap()` (converting panics to `Err`). This prevents crashes in scenarios like NaN comparisons, empty collections, poisoned mutexes, or panicked threads, making the application more resilient.

---
<p><a href="https://cursor.com/agents?id=bc-74f11a65-0c60-481d-b557-c7f030bab840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74f11a65-0c60-481d-b557-c7f030bab840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

