### PR TITLE
Add Ubuntu ARM build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,10 @@ jobs:
             target: x86_64-unknown-linux-gnu
             asset_name: musical-joycons-linux-x86_64
             archive_ext: tar.gz
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            asset_name: musical-joycons-linux-aarch64
+            archive_ext: tar.gz
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             asset_name: musical-joycons-windows-x86_64
@@ -67,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies (Linux)
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \

--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -31,13 +31,14 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
           - os: windows-latest
           - os: macos-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies (Linux)
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -63,13 +64,14 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
           - os: windows-latest
           - os: macos-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies (Linux)
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Musical-Joycons will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2026-02-26
+### Added
+- ARM64 (aarch64) Linux build target for use on devices like the Nintendo Switch running L4T Ubuntu.
+- Native ARM64 GitHub Actions runner (`ubuntu-24.04-arm`) for building and testing release binaries.
+
 ## [0.1.2] - 2026-02-24
 ### Added
 - Part-based MIDI normalization: notes grouped by `(channel, program)` into musical Parts, replacing raw track-based analysis.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "musical-joycons"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Play MIDI files through Nintendo JoyCon rumble motors"
 license = "MIT"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions matrices and metadata (version/changelog) with no runtime code modifications. Main risk is CI/release breakage if the `ubuntu-24.04-arm` runner or aarch64 build dependencies behave differently.
> 
> **Overview**
> Adds Linux ARM64 (`aarch64-unknown-linux-gnu`) to both CI and release build matrices using the `ubuntu-24.04-arm` runner, producing an additional `musical-joycons-linux-aarch64` release artifact.
> 
> Updates Linux dependency installation steps to run on any Linux runner (not just `ubuntu-latest`), and bumps the crate/changelog to `0.1.3` to document the new ARM build support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21b744dd8e315e81a6c50fd0115a88631a8826ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->